### PR TITLE
Add support for serializing LLSD types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-vv --cov=llsd_asgi --cov-report=xml"
+addopts = "-vv --cov=llsd_asgi --cov-report=xml --cov-report term-missing"
 testpaths = ["tests"]
 
 [build-system]


### PR DESCRIPTION
Add a custom JSONEncoder class that supports all LLSD types (datetime, bytes, uri, UUID, etc.)